### PR TITLE
refactor: remove unused parameter "album_id" from dar_canciones_de_album

### DIFF
--- a/src/logica/coleccion.py
+++ b/src/logica/coleccion.py
@@ -180,7 +180,7 @@ class Coleccion():
     def dar_interprete_por_id(self, interprete_id):
         return session.query(Interprete).filter_by(id=interprete_id).first().__dict__
 
-    def dar_canciones_de_album(self, album_id):
+    def dar_canciones_de_album(self):
         return []
 
     def buscar_canciones_por_titulo(self, cancion_titulo):


### PR DESCRIPTION
Fix Code Smell:
Intentionality
[Remove the unused function parameter "album_id".](https://sonarcloud.io/project/issues?open=AZLpXvqJ3F9vXsD95PWQ&id=dbuelvasc_sonar-tutorialcancionestags)